### PR TITLE
fix(temp): 主板温度主值优先 acpitz，SYSTIN 作回落

### DIFF
--- a/app.py
+++ b/app.py
@@ -763,8 +763,16 @@ def _parse_cpu_temp(j):
     return max(fallback) if fallback else None
 
 def _parse_mb_temp(j):
-    """统一主板温度解析（纯函数）：SYSTIN 精确测点优先；
-    回落排除 coretemp/AUX 后最高；再回落非 coretemp 最高。"""
+    """统一主板温度解析（纯函数）。
+
+    优先级（均带合理性护栏：0~90°C 视为有效，过滤传感器错误值）：
+      1) acpitz —— ACPI 固件报的「系统环境温度」，多数主板最稳、不易虚高
+                  （很多主板的 SYSTIN 是错的，论坛反馈据此优先取 acpitz）
+      2) SYSTIN  —— hwmon 上的精确测点
+      3) 排除 coretemp / AUXTIN 后的最高温
+      4) 非 coretemp 最高温（兜底）
+    任一来源无效/缺失则自动回落到下一来源，避免把传感器错误值当真。
+    """
     temps = []
     for chip, entries in (j or {}).items():
         if not isinstance(entries, dict):
@@ -777,15 +785,34 @@ def _parse_mb_temp(j):
                     temps.append((str(chip), str(ename), float(v)))
     if not temps:
         return None
-    systin = [t for t in temps if t[1].strip().upper() == "SYSTIN"]
+
+    def _sane(v):
+        return isinstance(v, (int, float)) and 0 <= v <= 90
+
+    # 1) acpitz（ACPI 系统环境温度）优先
+    acpitz = [t for t in temps if str(t[0]).lower().startswith("acpitz") and _sane(t[2])]
+    if acpitz:
+        return acpitz[0][2]
+
+    # 2) SYSTIN 精确测点
+    systin = [t for t in temps if t[1].strip().upper() == "SYSTIN" and _sane(t[2])]
     if systin:
         return systin[0][2]
-    mb = [t for t in temps if "coretemp" not in t[0].lower() and not t[1].strip().upper().startswith("AUXTIN")]
+
+    # 3) 排除 coretemp / AUXTIN 后的最高温
+    mb = [t for t in temps
+          if "coretemp" not in t[0].lower()
+          and not t[1].strip().upper().startswith("AUXTIN")
+          and _sane(t[2])]
     if mb:
         return max(t[2] for t in mb)
-    mb2 = [t for t in temps if "coretemp" not in t[0].lower()]
+
+    # 4) 非 coretemp 最高温（兜底）
+    mb2 = [t for t in temps if "coretemp" not in t[0].lower() and _sane(t[2])]
     if mb2:
         return max(t[2] for t in mb2)
+
+    # 5) 实在没有合理值，返回全部里的最高（保持旧行为兜底）
     return max(t[2] for t in temps)
 
 def _parse_sensors_all(j):

--- a/scripts/test_app_parsers.py
+++ b/scripts/test_app_parsers.py
@@ -318,11 +318,34 @@ def test_fan_read_sys_temp_cpu_amd_tdie(monkeypatch):
 
 
 def test_fan_read_sys_temp_mb_excludes_coretemp(monkeypatch):
+    # 无 acpitz / 无 SYSTIN 时，回落到「排除 coretemp/AUXTIN 后的最高温」
     sens = json.dumps({
         "coretemp-isa-0000": {"Package id 0": {"temp1_input": 70.0}},
         "it8620-isa-0290": {"temp1": {"temp1_input": 38.0}, "temp2": {"temp2_input": 41.0}},
     })
     assert app._parse_mb_temp(json.loads(sens)) == 41.0  # 主板温度取 it86 最高，不含 coretemp
+
+
+def test_fan_read_sys_temp_mb_prefers_acpitz(monkeypatch):
+    # 论坛反馈：SYSTIN 在很多主板是错的；应优先取 acpitz（ACPI 系统环境温度，稳定不虚高）
+    sens = json.dumps({
+        "acpitz-acpi-0": {"temp1": {"temp1_input": 33.0}},
+        "nct6797-isa-0a00": {
+            "SYSTIN": {"temp1_input": 62.0},   # 虚高（错误值）
+            "CPUTIN": {"temp2_input": 45.0},
+        },
+        "coretemp-isa-0000": {"Package id 0": {"temp1_input": 55.0}},
+    })
+    assert app._parse_mb_temp(json.loads(sens)) == 33.0  # 取 acpitz，而非 SYSTIN
+
+
+def test_fan_read_sys_temp_mb_acpitz_insane_falls_back(monkeypatch):
+    # acpitz 报出明显传感器错误（>90）时，应回落到 SYSTIN，而不是把错值当真
+    sens = json.dumps({
+        "acpitz-acpi-0": {"temp1": {"temp1_input": 127.0}},
+        "nct6797-isa-0a00": {"SYSTIN": {"temp1_input": 36.0}},
+    })
+    assert app._parse_mb_temp(json.loads(sens)) == 36.0
 
 
 # ---------------- Docker 资源解析（v1.10.0） ----------------


### PR DESCRIPTION
论坛反馈 bug：很多主板 SYSTIN 是错的（虚高/无效），ACPI 固件报的 acpitz 才是稳定的「系统环境温度」。

- `_parse_mb_temp` 改为 acpitz 优先（带 0~90°C 合理性护栏），SYSTIN 缺失/异常自动回落，行为不退化。
- 同步更新 unit test：原有「排除 coretemp」用例仍成立，新增 acpitz 优先 + acpitz 异常回落两条用例（本地 5/5 通过）。
- 已在 158 真机部署并重启运行验证（无崩溃）。