### PR TITLE
fix(temp): 面板主板温度展示与告警优先 acpitz，SYSTIN 降级保留

### DIFF
--- a/app.py
+++ b/app.py
@@ -875,6 +875,14 @@ def _parse_sensors_all(j):
                         nm = "CMOS 电池"
                     voltages.append({"name": nm, "value": round(v, 2)})
                     break
+    # 论坛反馈：很多主板 SYSTIN 是错的（虚高/无效），主板温度应优先用 ACPI(acpitz)
+    # 提供的稳定「系统环境温度」。若存在 acpitz，把「主板温度」主名让给它，SYSTIN 降级为「主板(SYSTIN)」。
+    _acpi_i = next((i for i, _t in enumerate(temps) if _t.get("name") == "主板(ACPI)"), None)
+    _systin_i = next((i for i, _t in enumerate(temps) if _t.get("name") == "主板温度"), None)
+    if _acpi_i is not None:
+        if _systin_i is not None:
+            temps[_systin_i]["name"] = "主板(SYSTIN)"
+        temps[_acpi_i]["name"] = "主板温度"
     return temps, voltages
 
 _TEMP_SNAP = {"t": 0.0, "cpu_temp": None, "mb_temp": None, "temps": [], "voltages": [], "disks": {}, "raid_temp": None}
@@ -7267,6 +7275,13 @@ def _save_alerts(cfg):
 
 def _mb_temp_from_sensors(sensors):
     temps = (sensors or {}).get("temps", []) or []
+    # 优先取 acpitz 优先后的「主板温度」主值（论坛反馈：SYSTIN 很多主板错，acpitz 更稳）
+    _primary = [t for t in temps if t.get("name") == "主板温度"]
+    if _primary:
+        try:
+            return float(_primary[0]["value"])
+        except (TypeError, ValueError):
+            pass
     cand = []
     for t in temps:
         name = (t.get("name") or "")

--- a/scripts/test_app_parsers.py
+++ b/scripts/test_app_parsers.py
@@ -348,6 +348,33 @@ def test_fan_read_sys_temp_mb_acpitz_insane_falls_back(monkeypatch):
     assert app._parse_mb_temp(json.loads(sens)) == 36.0
 
 
+def test_sensors_all_mb_temp_prefers_acpitz(monkeypatch):
+    # 论坛反馈 bug 核心：面板「主板温度」条目应优先用 acpitz（ACPI 系统环境温度，稳定），
+    # 而非 SYSTIN（很多主板是错的）。SYSTIN 降级为「主板(SYSTIN)」保留展示，不丢信息。
+    sens = json.dumps({
+        "acpitz-acpi-0": {"temp1": {"temp1_input": 28.0}},
+        "nct6797-isa-0a00": {
+            "SYSTIN": {"temp1_input": 43.0},   # 虚高（错误值）
+            "CPUTIN": {"temp2_input": 36.0},
+            "AUXTIN": {"temp3_input": 999.0},  # 异常值，应被忽略
+        },
+    })
+    temps, _ = app._parse_sensors_all(json.loads(sens))
+    names = {t["name"]: t["value"] for t in temps}
+    assert names.get("主板温度") == 28, "主板温度应=acpitz(28)，而非 SYSTIN(43)"
+    assert names.get("主板(SYSTIN)") == 43, "SYSTIN 应降级为「主板(SYSTIN)」"
+    assert "主板(ACPI)" not in names, "主板(ACPI)应已合并改名"
+
+
+def test_mb_temp_from_sensors_prefers_acpitz(monkeypatch):
+    # 告警判定（主板/芯片组温度过高）也应取 acpitz 优先后的「主板温度」主值
+    sensors = {"temps": [
+        {"name": "主板温度", "value": 28.0},
+        {"name": "主板(SYSTIN)", "value": 43.0},
+    ]}
+    assert app._mb_temp_from_sensors(sensors) == 28.0
+
+
 # ---------------- Docker 资源解析（v1.10.0） ----------------
 def test_docker_size_to_bytes():
     assert app._docker_size_to_bytes("120MiB") == 120 * 1024 ** 2


### PR DESCRIPTION
上一轮 PR#22 只改了 _parse_mb_temp（仅 hero 卡片/风扇控温用的 mb_temp），但用户在面板里看到的「主板温度」条目来自 _parse_sensors_all 的 SYSTIN→主板温度 映射，与告警判定用的 _mb_temp_from_sensors，两处都没动——等于改错地方。

本次修正真正的展示/告警源头：
- _parse_sensors_all：存在 acpitz 时把「主板温度」主名让给它（=acpitz 值），SYSTIN 降级为「主板(SYSTIN)」保留；无 acpitz 时回退 SYSTIN，不退化。
- _mb_temp_from_sensors：优先取 acpitz 优先后的「主板温度」主值。
- 真机 158 部署后 /api/all 实测：system.temps.主板温度 由 43(SYSTIN) 变为 28(acpitz)，主板(SYSTIN)=43 保留。
- 补全 test_app_parsers.py 两条用例。